### PR TITLE
Feature/use go gh

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,20 +69,6 @@ func main() {
 		verbose = true
 	}
 
-	fmt.Println("hi world, this is the gh-aipr extension!")
-	client, err := api.DefaultRESTClient()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	response := struct{ Login string }{}
-	err = client.Get("user", &response)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	fmt.Printf("running as %s\n", response.Login)
-
 	diffOutput, err := getGitDiff()
 	if err != nil {
 		fmt.Println("Error getting git diff:", err)

--- a/main.go
+++ b/main.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/cli/go-gh/v2/pkg/repository"
 )
 
 const openAIURL = "https://api.openai.com/v1/chat/completions"
@@ -24,15 +24,26 @@ type Config struct {
 var verbose bool // Global flag to control verbose output
 
 func getGitDiff() (string, error) {
-	// Determine the default branch
-	defaultBranchCmd := exec.Command("sh", "-c", "git remote show origin | awk '/HEAD branch/ {print $NF}'")
-	var defaultBranchOut bytes.Buffer
-	defaultBranchCmd.Stdout = &defaultBranchOut
-	err := defaultBranchCmd.Run()
+	// Determine the default branch using go-gh
+	client, err := api.DefaultRESTClient()
 	if err != nil {
 		return "", err
 	}
-	defaultBranch := strings.TrimSpace(defaultBranchOut.String())
+	repo, err := repository.Current()
+	if err != nil {
+		return "", err
+	}
+	var repoInfo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	err = client.Get(fmt.Sprintf("repos/%s/%s", repo.Owner, repo.Name), &repoInfo)
+	if err != nil {
+		return "", err
+	}
+	defaultBranch := repoInfo.DefaultBranch
+	if err != nil {
+		return "", err
+	}
 
 	// Get the git diff with the default branch
 	diffCmd := exec.Command("git", "diff", "origin/"+defaultBranch)


### PR DESCRIPTION
## Description

* This pull request refactors the logic for retrieving the git diff by using the `go-gh` library to determine the default branch of the repository.

### Changes
1. Refactor default branch determination:
   - Replaced shell command execution with `go-gh` library to fetch the default branch of the repository.

2. Update `getGitDiff` function:
   - Integrated `go-gh` library to retrieve repository information and determine the default branch.

3. Code cleanup:
   - Removed redundant code and unused imports.

### Testing
- Verified that the default branch is correctly determined using the `go-gh` library.
- Tested the `getGitDiff` function to ensure it retrieves the correct git diff against the default branch.
- Ensured that the application runs without errors and performs as expected.