### PR TITLE
Add Instruction to Omit Git Diff in Pull Request Message

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -6,6 +6,7 @@ import "fmt"
 func CreateOpenAIQuestion(diffOutput string) string {
 	prompt := `
 Please generate appropriate pull request message based on the context.
+(Do not output the result of git diff)
 
 Here is a sample of pull-request format.
 


### PR DESCRIPTION
## Description

* This pull request adds an instruction to omit the result of `git diff` in the generated pull request message.

### Changes
1. Update `CreateOpenAIQuestion` function:
   - Added a line to instruct the user not to output the result of `git diff` in the generated pull request message.

### Testing
- Verified that the prompt now includes the instruction to omit the result of `git diff` in the generated pull request message.