### PR TITLE
Add Help Option to Command Line Interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,13 @@ func getGitDiff() (string, error) {
 	return diffOut.String(), nil
 }
 
+func printHelp() {
+	fmt.Println("Usage: go run main.go [options]")
+	fmt.Println("Options:")
+	fmt.Println("  -h, --help     Show this help message")
+	fmt.Println("  -v, --verbose  Enable verbose output")
+}
+
 func main() {
 	var config Config
 	err := envconfig.Process("", &config)
@@ -65,8 +72,13 @@ func main() {
 	}
 
 	verbose = false // Default verbose to false
-	if len(os.Args) > 1 && os.Args[1] == "-v" {
-		verbose = true
+	if len(os.Args) > 1 {
+		if os.Args[1] == "-h" || os.Args[1] == "--help" {
+			printHelp()
+			return
+		} else if os.Args[1] == "-v" || os.Args[1] == "--verbose" {
+			verbose = true
+		}
 	}
 
 	diffOutput, err := getGitDiff()


### PR DESCRIPTION
## Description

* This pull request adds a help option to the command line interface of the application, providing users with guidance on how to use the available options.

### Changes
1. Added `printHelp` function:
   - This function prints usage instructions and available options to the console.

2. Updated `main` function:
   - Added logic to check for `-h` or `--help` arguments and display the help message.
   - Enhanced verbose option to also recognize `--verbose` in addition to `-v`.

### Testing
- Verified that running the application with `-h` or `--help` displays the help message.
- Confirmed that the verbose mode is enabled when using either `-v` or `--verbose`.
- Ensured that the application behaves as expected when no options or other options are provided.