### PR TITLE
Add title-only and body-only flags for pull request generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,8 +170,8 @@ func main() {
 		return
 	}
 
-	titlePrompt := CreateOpenAIQuestion("title", diffOutput)
-	bodyPrompt := CreateOpenAIQuestion("body", diffOutput)
+	titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput)
+	bodyPrompt := CreateOpenAIQuestion(PrBody, diffOutput)
 	title, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
 	if err != nil {
 		fmt.Println("Error asking OpenAI for title:", err)

--- a/main.go
+++ b/main.go
@@ -24,8 +24,9 @@ type Config struct {
 }
 
 var (
-	verbose bool // Global flag to control verbose output
-	create  bool // Global flag to control pull request creation
+	verbose   bool // Global flag to control verbose output
+	create    bool // Global flag to control pull request creation
+	titleOnly bool // Global flag to control title-only output
 )
 
 func printHelp() {
@@ -36,9 +37,10 @@ USAGE
   gh aipr [flags]
 
 FLAGS
-  --help     Show help for command
-  --verbose  Enable verbose output
-  --create   Create a pull request
+  --help      Show help for command
+  --verbose   Enable verbose output
+  --create    Create a pull request
+  --title     Output only the title
 
 EXAMPLES
   $ gh aipr --help
@@ -151,6 +153,7 @@ func main() {
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose output")
 	flag.BoolVar(&create, "create", false, "Create a pull request")
 	flag.BoolVar(&showHelp, "help", false, "Show help for command")
+	flag.BoolVar(&titleOnly, "title", false, "Output only the title")
 	flag.Parse()
 
 	if showHelp {
@@ -183,7 +186,10 @@ func main() {
 		return
 	}
 
-	if create {
+	if titleOnly {
+		fmt.Println("Generated Pull Request Title:")
+		fmt.Println(title)
+	} else if create {
 		prNumber, err := createPullRequest(title, body, defaultBranch)
 		if err != nil {
 			fmt.Println("Error creating pull request:", err)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	verbose   bool // Global flag to control verbose output
 	create    bool // Global flag to control pull request creation
 	titleOnly bool // Global flag to control title-only output
+	bodyOnly  bool // Global flag to control body-only output
 )
 
 func printHelp() {
@@ -41,6 +42,7 @@ FLAGS
   --verbose   Enable verbose output
   --create    Create a pull request
   --title     Output only the title
+  --body      Output only the body
 
 EXAMPLES
   $ gh aipr --help
@@ -154,6 +156,7 @@ func main() {
 	flag.BoolVar(&create, "create", false, "Create a pull request")
 	flag.BoolVar(&showHelp, "help", false, "Show help for command")
 	flag.BoolVar(&titleOnly, "title", false, "Output only the title")
+	flag.BoolVar(&bodyOnly, "body", false, "Output only the body")
 	flag.Parse()
 
 	if showHelp {
@@ -186,16 +189,19 @@ func main() {
 		return
 	}
 
-	if titleOnly {
-		fmt.Println("Generated Pull Request Title:")
-		fmt.Println(title)
-	} else if create {
+	if create {
 		prNumber, err := createPullRequest(title, body, defaultBranch)
 		if err != nil {
 			fmt.Println("Error creating pull request:", err)
 		} else {
 			fmt.Println(prNumber)
 		}
+	} else if titleOnly {
+		fmt.Println("Generated Pull Request Title:")
+		fmt.Println(title)
+	} else if bodyOnly {
+		fmt.Println("Generated Pull Request Description:")
+		fmt.Println(body)
 	} else {
 		fmt.Println("Generated Pull Request Title:")
 		fmt.Println(title)

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func main() {
 	}
 
 	if create {
-		prNumber, err := createPullRequest(strings.TrimPrefix(title, "## "), body, defaultBranch)
+		prNumber, err := createPullRequest(title, body, defaultBranch)
 		if err != nil {
 			fmt.Println("Error creating pull request:", err)
 		} else {

--- a/main.go
+++ b/main.go
@@ -170,10 +170,16 @@ func main() {
 		return
 	}
 
-	question := CreateOpenAIQuestion(diffOutput)
-	title, body, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, question, verbose)
+	titlePrompt := CreateOpenAIQuestion("title", diffOutput)
+	bodyPrompt := CreateOpenAIQuestion("body", diffOutput)
+	title, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
 	if err != nil {
-		fmt.Println("Error asking OpenAI:", err)
+		fmt.Println("Error asking OpenAI for title:", err)
+		return
+	}
+	body, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, bodyPrompt, verbose)
+	if err != nil {
+		fmt.Println("Error asking OpenAI for body:", err)
 		return
 	}
 

--- a/prompt.go
+++ b/prompt.go
@@ -2,15 +2,22 @@ package main
 
 import "fmt"
 
-func CreateOpenAIQuestion(promptType, diffOutput string) string {
-	if promptType == "title" {
+type PromptType int
+
+const (
+	PrTitle PromptType = iota
+	PrBody
+)
+
+func CreateOpenAIQuestion(promptType PromptType, diffOutput string) string {
+	if promptType == PrTitle {
 		return fmt.Sprintf(`
 Please generate an appropriate pull request title based on the context.
 (Output only the title in one line.)
 (Do not output the result of git diff)
 
 %s`, diffOutput)
-	} else if promptType == "body" {
+	} else if promptType == PrBody {
 		return fmt.Sprintf(`
 Please generate an appropriate pull request description based on the context.
 (Do not output the result of git diff)

--- a/prompt.go
+++ b/prompt.go
@@ -2,18 +2,22 @@ package main
 
 import "fmt"
 
-// CreateOpenAIQuestion formats a question for the OpenAI API based on the git diff output.
-func CreateOpenAIQuestion(diffOutput string) string {
-	prompt := `
-Please generate appropriate pull request message based on the context.
+func CreateOpenAIQuestion(promptType, diffOutput string) string {
+	if promptType == "title" {
+		return fmt.Sprintf(`
+Please generate an appropriate pull request title based on the context.
+(Output only the title in one line.)
 (Do not output the result of git diff)
 
-Here is a sample of pull-request format.
+%s`, diffOutput)
+	} else if promptType == "body" {
+		return fmt.Sprintf(`
+Please generate an appropriate pull request description based on the context.
+(Do not output the result of git diff)
+
+Here is a sample of pull-request description format.
 
 ---
-## Pull Request Title
-
-
 ## Description
 
 * desc 
@@ -36,7 +40,7 @@ Here is a sample of pull-request format.
 - desc
 
 ---
-
-%s`
-	return fmt.Sprintf(prompt, diffOutput)
+%s`, diffOutput)
+	}
+	return ""
 }


### PR DESCRIPTION
---
## Description

This pull request enhances the functionality of the `gh aipr` command by adding new flags and refactoring the code to improve readability and maintainability.

### Changes
1. **New Flags:**
   - Added `--title` flag to output only the pull request title.
   - Added `--body` flag to output only the pull request description.

2. **Refactored Flag Handling:**
   - Updated the `main.go` file to handle the new flags and their respective functionalities.
   - Modified the `printHelp` function to include descriptions for the new flags.

3. **OpenAI Integration:**
   - Split the OpenAI request into separate prompts for title and body generation.
   - Updated the `AskOpenAI` function to return a single string response instead of splitting it into title and body.

4. **Prompt Generation:**
   - Introduced a new `PromptType` enum to differentiate between title and body prompts.
   - Updated the `CreateOpenAIQuestion` function to generate appropriate prompts based on the `PromptType`.

### Testing
- Verified that the `--title` flag outputs only the generated pull request title.
- Verified that the `--body` flag outputs only the generated pull request description.
- Tested the `--create` flag to ensure it creates a pull request with the generated title and description.
- Ensured that the help message displays the correct information for all flags.

---