### PR TITLE
Add Japanese Output Option to Pull Request Title and Description Generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ FLAGS
   --title      Output only the title
   --body       Output only the body
   --japanise   Output in Japanese
-  --japanise   Output in Japanese
 
 EXAMPLES
   $ gh aipr --help
@@ -160,7 +159,6 @@ func main() {
 	flag.BoolVar(&showHelp, "help", false, "Show help for command")
 	flag.BoolVar(&titleOnly, "title", false, "Output only the title")
 	flag.BoolVar(&bodyOnly, "body", false, "Output only the body")
-	flag.BoolVar(&japanise, "japanise", false, "Output in Japanese")
 	flag.BoolVar(&japanise, "japanise", false, "Output in Japanese")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -179,14 +179,40 @@ func main() {
 		return
 	}
 
+	var title, body string
+
+	if titleOnly {
+		titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput, japanise)
+		title, err = AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
+		if err != nil {
+			fmt.Println("Error asking OpenAI for title:", err)
+			return
+		}
+		fmt.Println("Generated Pull Request Title:")
+		fmt.Println(title)
+		return
+	}
+
+	if bodyOnly {
+		bodyPrompt := CreateOpenAIQuestion(PrBody, diffOutput, japanise)
+		body, err = AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, bodyPrompt, verbose)
+		if err != nil {
+			fmt.Println("Error asking OpenAI for body:", err)
+			return
+		}
+		fmt.Println("Generated Pull Request Description:")
+		fmt.Println(body)
+		return
+	}
+
 	titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput, japanise)
 	bodyPrompt := CreateOpenAIQuestion(PrBody, diffOutput, japanise)
-	title, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
+	title, err = AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
 	if err != nil {
 		fmt.Println("Error asking OpenAI for title:", err)
 		return
 	}
-	body, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, bodyPrompt, verbose)
+	body, err = AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, bodyPrompt, verbose)
 	if err != nil {
 		fmt.Println("Error asking OpenAI for body:", err)
 		return
@@ -199,12 +225,6 @@ func main() {
 		} else {
 			fmt.Println(prNumber)
 		}
-	} else if titleOnly {
-		fmt.Println("Generated Pull Request Title:")
-		fmt.Println(title)
-	} else if bodyOnly {
-		fmt.Println("Generated Pull Request Description:")
-		fmt.Println(body)
 	} else {
 		fmt.Println("Generated Pull Request Title:")
 		fmt.Println(title)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	create    bool // Global flag to control pull request creation
 	titleOnly bool // Global flag to control title-only output
 	bodyOnly  bool // Global flag to control body-only output
+	japanise  bool // Global flag to control Japanese output
 )
 
 func printHelp() {
@@ -38,11 +39,13 @@ USAGE
   gh aipr [flags]
 
 FLAGS
-  --help      Show help for command
-  --verbose   Enable verbose output
-  --create    Create a pull request
-  --title     Output only the title
-  --body      Output only the body
+  --help       Show help for command
+  --verbose    Enable verbose output
+  --create     Create a pull request
+  --title      Output only the title
+  --body       Output only the body
+  --japanise   Output in Japanese
+  --japanise   Output in Japanese
 
 EXAMPLES
   $ gh aipr --help
@@ -157,6 +160,8 @@ func main() {
 	flag.BoolVar(&showHelp, "help", false, "Show help for command")
 	flag.BoolVar(&titleOnly, "title", false, "Output only the title")
 	flag.BoolVar(&bodyOnly, "body", false, "Output only the body")
+	flag.BoolVar(&japanise, "japanise", false, "Output in Japanese")
+	flag.BoolVar(&japanise, "japanise", false, "Output in Japanese")
 	flag.Parse()
 
 	if showHelp {
@@ -176,8 +181,8 @@ func main() {
 		return
 	}
 
-	titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput)
-	bodyPrompt := CreateOpenAIQuestion(PrBody, diffOutput)
+	titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput, japanise)
+	bodyPrompt := CreateOpenAIQuestion(PrBody, diffOutput, japanise)
 	title, err := AskOpenAI(openAIURL, config.OpenAIKey, config.OpenAIModel, config.OpenAITemperature, config.OpenAIMaxTokens, titlePrompt, verbose)
 	if err != nil {
 		fmt.Println("Error asking OpenAI for title:", err)

--- a/prompt.go
+++ b/prompt.go
@@ -9,16 +9,57 @@ const (
 	PrBody
 )
 
-func CreateOpenAIQuestion(promptType PromptType, diffOutput string) string {
-	if promptType == PrTitle {
-		return fmt.Sprintf(`
+func CreateOpenAIQuestion(promptType PromptType, diffOutput string, japanise bool) string {
+	if japanise {
+		if promptType == PrTitle {
+			return fmt.Sprintf(`
+プルリクエストのタイトルを生成してください。
+（タイトルのみを一行で出力してください。）
+（git diffの結果を出力しないでください。）
+
+%s`, diffOutput)
+		} else if promptType == PrBody {
+			return fmt.Sprintf(`
+プルリクエストの説明を生成してください。
+（git diffの結果を出力しないでください。）
+
+以下はプルリクエスト説明フォーマットのサンプルです。
+
+---
+## 説明
+
+* 説明
+
+### 変更点
+1. 変更点:
+   - 説明
+
+2. 変更点:
+   - 説明
+
+3. 変更点:
+   - 説明
+
+...
+...
+...
+
+### テスト
+- 説明
+
+---
+%s`, diffOutput)
+		}
+	} else {
+		if promptType == PrTitle {
+			return fmt.Sprintf(`
 Please generate an appropriate pull request title based on the context.
 (Output only the title in one line.)
 (Do not output the result of git diff)
 
 %s`, diffOutput)
-	} else if promptType == PrBody {
-		return fmt.Sprintf(`
+		} else if promptType == PrBody {
+			return fmt.Sprintf(`
 Please generate an appropriate pull request description based on the context.
 (Do not output the result of git diff)
 
@@ -48,6 +89,7 @@ Here is a sample of pull-request description format.
 
 ---
 %s`, diffOutput)
+		}
 	}
 	return ""
 }

--- a/prompt.go
+++ b/prompt.go
@@ -13,7 +13,7 @@ func CreateOpenAIQuestion(promptType PromptType, diffOutput string, japanise boo
 	if japanise {
 		if promptType == PrTitle {
 			return fmt.Sprintf(`
-プルリクエストのタイトルを生成してください。
+コンテキストに基づいて適切なプルリクエストのタイトルを生成してください。
 （タイトルのみを一行で出力してください。）
 （git diffの結果を出力しないでください。）
 


### PR DESCRIPTION
---
## Description

This pull request introduces a new feature to support Japanese output for the `gh aipr` command. The changes include adding a new global flag `--japanise` and modifying the existing functions to handle Japanese output based on this flag.

### Changes
1. Added a new global flag:
   - `japanise` to control Japanese output.

2. Updated the `printHelp` function:
   - Included the `--japanise` flag in the help message.

3. Modified the `main` function:
   - Added logic to handle the `japanise` flag for title-only and body-only outputs.
   - Adjusted the prompts for OpenAI requests to include the `japanise` flag.

4. Updated the `CreateOpenAIQuestion` function:
   - Added a parameter to handle Japanese output.
   - Included Japanese templates for generating pull request titles and descriptions.

### Testing
- Verified that the `--japanise` flag correctly generates Japanese output for both title and body.
- Tested the `--title`, `--body`, and `--create` flags in combination with `--japanise` to ensure proper functionality.
- Ensured that the help message displays the new `--japanise` flag correctly.

---