### PR TITLE
Add Anthropic API support and provider selection to AI-powered PR title/description generation

### DIFF
--- a/ai.go
+++ b/ai.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AskAI is a unified function that routes requests to either OpenAI or Anthropic API
+// based on the configuration and command-line flags
+func AskAI(config Config, question string, verbose bool) (string, error) {
+	// Determine which provider to use
+	provider := config.Provider
+	if provider == "" {
+		provider = "openai" // Default to OpenAI if not specified
+	}
+	
+	// Override provider if specified via command line
+	if provider != "" {
+		provider = strings.ToLower(provider)
+	}
+	
+	// Route based on provider
+	switch provider {
+	case "openai":
+		// Determine which model to use
+		model := config.OpenAIModel
+		if modelName != "" {
+			model = modelName
+		}
+		
+		// Check if API key is available
+		if config.OpenAIKey == "" {
+			return "", fmt.Errorf("OpenAI API key not found. Set the OPENAI_API_KEY environment variable")
+		}
+		
+		return AskOpenAI(openAIURL, config.OpenAIKey, model, config.OpenAITemperature, config.OpenAIMaxTokens, question, verbose)
+		
+	case "anthropic":
+		// Determine which model to use
+		model := config.AnthropicModel
+		if modelName != "" {
+			model = modelName
+		}
+		
+		// Check if API key is available
+		if config.AnthropicKey == "" {
+			return "", fmt.Errorf("Anthropic API key not found. Set the ANTHROPIC_API_KEY environment variable")
+		}
+		
+		return AskAnthropic(config.AnthropicKey, model, config.AnthropicTemperature, config.AnthropicMaxTokens, question, verbose)
+		
+	default:
+		return "", fmt.Errorf("unsupported AI provider: %s. Use 'openai' or 'anthropic'", provider)
+	}
+}

--- a/ai.go
+++ b/ai.go
@@ -6,7 +6,7 @@ import (
 )
 
 // AskAI is a unified function that routes requests to either OpenAI or Anthropic API
-// based on the configuration and command-line flags
+// based on the configuration
 func AskAI(config Config, question string, verbose bool) (string, error) {
 	// Determine which provider to use
 	provider := config.Provider
@@ -14,19 +14,13 @@ func AskAI(config Config, question string, verbose bool) (string, error) {
 		provider = "openai" // Default to OpenAI if not specified
 	}
 	
-	// Override provider if specified via command line
-	if provider != "" {
-		provider = strings.ToLower(provider)
-	}
+	provider = strings.ToLower(provider)
 	
 	// Route based on provider
 	switch provider {
 	case "openai":
 		// Determine which model to use
 		model := config.OpenAIModel
-		if modelName != "" {
-			model = modelName
-		}
 		
 		// Check if API key is available
 		if config.OpenAIKey == "" {
@@ -38,9 +32,6 @@ func AskAI(config Config, question string, verbose bool) (string, error) {
 	case "anthropic":
 		// Determine which model to use
 		model := config.AnthropicModel
-		if modelName != "" {
-			model = modelName
-		}
 		
 		// Check if API key is available
 		if config.AnthropicKey == "" {

--- a/anthropic.go
+++ b/anthropic.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const anthropicURL = "https://api.anthropic.com/v1/messages"
+
+type AnthropicRequest struct {
+	Model       string             `json:"model"`
+	Messages    []AnthropicMessage `json:"messages"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature float64            `json:"temperature"`
+}
+
+type AnthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type AnthropicResponse struct {
+	Content []struct {
+		Type  string `json:"type"`
+		Text  string `json:"text"`
+	} `json:"content"`
+}
+
+func AskAnthropic(apiKey, model string, temperature float64, maxTokens int, question string, verbose bool) (string, error) {
+	// Start the spinner
+	spinner := NewSpinner("Asking Anthropic")
+	spinner.Start()
+	defer spinner.Stop()
+
+	data := AnthropicRequest{
+		Messages:    []AnthropicMessage{{Role: "user", Content: question}},
+		Model:       model,
+		Temperature: temperature,
+		MaxTokens:   maxTokens,
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	body := bytes.NewReader(payloadBytes)
+
+	req, err := http.NewRequest("POST", anthropicURL, body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received non-OK HTTP status from Anthropic: %s", resp.Status)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if verbose {
+		fmt.Printf("\nRaw response from Anthropic: %v", string(respBody))
+	}
+
+	var apiResp AnthropicResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return "", err
+	}
+
+	if len(apiResp.Content) > 0 {
+		var responseBuilder strings.Builder
+		for _, content := range apiResp.Content {
+			if content.Type == "text" {
+				responseBuilder.WriteString(content.Text)
+			}
+		}
+		return strings.TrimSpace(responseBuilder.String()), nil
+	}
+
+	return "", fmt.Errorf("no response from Anthropic")
+}

--- a/main.go
+++ b/main.go
@@ -34,13 +34,11 @@ type Config struct {
 }
 
 var (
-	verbose   bool   // Global flag to control verbose output
-	create    bool   // Global flag to control pull request creation
-	titleOnly bool   // Global flag to control title-only output
-	bodyOnly  bool   // Global flag to control body-only output
-	japanise  bool   // Global flag to control Japanese output
-	modelName string // Global flag to specify the model name
-	provider  string // Global flag to specify the AI provider (openai or anthropic)
+	verbose   bool // Global flag to control verbose output
+	create    bool // Global flag to control pull request creation
+	titleOnly bool // Global flag to control title-only output
+	bodyOnly  bool // Global flag to control body-only output
+	japanise  bool // Global flag to control Japanese output
 )
 
 func printHelp() {
@@ -57,14 +55,10 @@ FLAGS
   --title        Output only the title
   --body         Output only the body
   --japanise     Output in Japanese
-  -m, --m        Specify the model name to use
-  -p, --p        Specify the AI provider to use (openai or anthropic)
 
 EXAMPLES
   $ gh aipr --help
   $ gh aipr --verbose
-  $ gh aipr -m gpt-4o
-  $ gh aipr -p anthropic -m claude-3-sonnet-20240229
 
 ENVIRONMENT VARIABLES
   # OpenAI configuration
@@ -186,8 +180,6 @@ func main() {
 	flag.BoolVar(&titleOnly, "title", false, "Output only the title")
 	flag.BoolVar(&bodyOnly, "body", false, "Output only the body")
 	flag.BoolVar(&japanise, "japanise", false, "Output in Japanese")
-	flag.StringVar(&modelName, "m", "", "Specify the model name to use")
-	flag.StringVar(&provider, "p", "", "Specify the AI provider to use (openai or anthropic)")
 	flag.Parse()
 
 	if showHelp {
@@ -222,10 +214,6 @@ func main() {
 	promptSpinner.Start()
 	promptSpinner.Stop()
 
-	// If command line provider is specified, override config provider
-	if provider != "" {
-		config.Provider = provider
-	}
 
 	if titleOnly {
 		titlePrompt := CreateOpenAIQuestion(PrTitle, diffOutput, japanise)


### PR DESCRIPTION
---
## Description

This pull request adds support for Anthropic's Claude API as an alternative AI provider alongside OpenAI. Users can now select which provider to use for generating pull request titles and descriptions via configuration or environment variables. The implementation includes a unified interface for routing requests to either OpenAI or Anthropic based on user preference.

### Changes
1. **Provider Abstraction**:
   - Introduced a new `Provider` field in the `Config` struct to allow selection between OpenAI and Anthropic.
   - Added logic to route AI requests to the appropriate provider in a new `AskAI` function.

2. **Anthropic API Integration**:
   - Added a new file `anthropic.go` implementing the `AskAnthropic` function for calling Anthropic's Claude API.
   - Defined request and response structures for Anthropic's API.
   - Implemented error handling and response parsing for Anthropic.

3. **Configuration Enhancements**:
   - Updated the `Config` struct to include Anthropic-specific fields (API key, model, temperature, max tokens).
   - Updated help and environment variable documentation to reflect new configuration options for Anthropic.

4. **Main Logic Updates**:
   - Replaced direct calls to `AskOpenAI` with the new `AskAI` function, enabling dynamic provider selection.
   - Improved error messages to be provider-agnostic.
   - Updated CLI help output to document Anthropic support and new environment variables.

### Testing
- Verified that pull request title and body generation works with both OpenAI and Anthropic by setting the `AI_PROVIDER` environment variable.
- Confirmed that appropriate error messages are shown when required API keys are missing.
- Checked that help output and environment variable documentation are accurate and up to date.
- Manually tested with both providers to ensure correct routing and response handling.

---